### PR TITLE
Avoid passing null to StructuredPopup::stripTags()

### DIFF
--- a/src/Map/StructuredPopup.php
+++ b/src/Map/StructuredPopup.php
@@ -29,7 +29,7 @@ class StructuredPopup {
 		$lines = [];
 
 		foreach ( $this->propertyValues as $name => $value ) {
-			$lines[] = $this->bold( $this->stripTags( $name ) ) . ': ' . $this->stripTags( $value );
+			$lines[] = $this->bold( $this->stripTags( $name ) ) . ': ' . $this->stripTags( strval( $value ) );
 		}
 
 		return implode( '<br>', $lines );


### PR DESCRIPTION
Because property values can be null at this point, it's necessary
to cast to a string.