### PR TITLE
Deprecate SkinTemplateNavigation in favor of SkinTemplateNavigation::Universal

### DIFF
--- a/src/MapsHooks.php
+++ b/src/MapsHooks.php
@@ -72,7 +72,7 @@ final class MapsHooks {
 		return true;
 	}
 
-	public static function onSkinTemplateNavigation( SkinTemplate $skinTemplate, array &$links ) {
+	public static function onSkinTemplateNavigationUniversal( SkinTemplate $skinTemplate, array &$links ) {
 		if ( $skinTemplate->getTitle() === null ) {
 			return true;
 		}

--- a/src/MapsSetup.php
+++ b/src/MapsSetup.php
@@ -102,7 +102,7 @@ class MapsSetup {
 	private function registerHooks() {
 		$GLOBALS['wgHooks']['AdminLinks'][] = 'Maps\MapsHooks::addToAdminLinks';
 		$GLOBALS['wgHooks']['MakeGlobalVariablesScript'][] = 'Maps\MapsHooks::onMakeGlobalVariablesScript';
-		$GLOBALS['wgHooks']['SkinTemplateNavigation'][] = 'Maps\MapsHooks::onSkinTemplateNavigation';
+		$GLOBALS['wgHooks']['SkinTemplateNavigation::Universal'][] = 'Maps\MapsHooks::onSkinTemplateNavigation';
 		$GLOBALS['wgHooks']['BeforeDisplayNoArticleText'][] = 'Maps\MapsHooks::onBeforeDisplayNoArticleText';
 		$GLOBALS['wgHooks']['ShowMissingArticle'][] = 'Maps\MapsHooks::onShowMissingArticle';
 		$GLOBALS['wgHooks']['ListDefinedTags'][] = 'Maps\MapsHooks::onRegisterTags';

--- a/src/MapsSetup.php
+++ b/src/MapsSetup.php
@@ -102,7 +102,7 @@ class MapsSetup {
 	private function registerHooks() {
 		$GLOBALS['wgHooks']['AdminLinks'][] = 'Maps\MapsHooks::addToAdminLinks';
 		$GLOBALS['wgHooks']['MakeGlobalVariablesScript'][] = 'Maps\MapsHooks::onMakeGlobalVariablesScript';
-		$GLOBALS['wgHooks']['SkinTemplateNavigation::Universal'][] = 'Maps\MapsHooks::onSkinTemplateNavigation';
+		$GLOBALS['wgHooks']['SkinTemplateNavigation::Universal'][] = 'Maps\MapsHooks::onSkinTemplateNavigationUniversal';
 		$GLOBALS['wgHooks']['BeforeDisplayNoArticleText'][] = 'Maps\MapsHooks::onBeforeDisplayNoArticleText';
 		$GLOBALS['wgHooks']['ShowMissingArticle'][] = 'Maps\MapsHooks::onShowMissingArticle';
 		$GLOBALS['wgHooks']['ListDefinedTags'][] = 'Maps\MapsHooks::onRegisterTags';


### PR DESCRIPTION
SkinTemplateNavigation was deprecated in 1.39.

SkinTemplateNavigation::Universal is available since 1.18
