### PR TITLE
Fix support for cargo

### DIFF
--- a/src/Map/CargoFormat/CargoFormat.php
+++ b/src/Map/CargoFormat/CargoFormat.php
@@ -11,8 +11,8 @@ class CargoFormat extends CargoDisplayFormat {
 
 	private \ParserOutput $parserOutput;
 
-	public function __construct( \ParserOutput $parserOutput ) {
-		parent::__construct( $parserOutput );
+	public function __construct( \OutputPage $output, \ParserOutput $parserOutput ) {
+		parent::__construct( $output, $parserOutput );
 		$this->parserOutput = $parserOutput;
 	}
 


### PR DESCRIPTION
Getting "Argument 1 passed to Maps\Map\CargoFormat\CargoFormat::__construct() must be an instance of ParserOutput, instance of OutputPage given, called in /srv/mediawiki/w/extensions/Cargo/includes/CargoQueryDisplayer.php on line 90"