### PR TITLE
Remove deprecated method Content::fillParserOutput()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
             php: 7.4
           - mw: 'REL1_38'
             php: 8.0
-#          - mw: 'REL1_39'
-#            php: 8.1
+          - mw: 'REL1_39'
+            php: 8.1
 #          - mw: 'master'
 #            php: 8.1
 

--- a/src/GeoJsonPages/GeoJsonContent.php
+++ b/src/GeoJsonPages/GeoJsonContent.php
@@ -5,12 +5,7 @@ declare( strict_types = 1 );
 namespace Maps\GeoJsonPages;
 
 use FormatJson;
-use Maps\MapsFactory;
-use Maps\Presentation\OutputFacade;
-use ParserOptions;
-use ParserOutput;
 use Status;
-use Title;
 
 class GeoJsonContent extends \JsonContent {
 
@@ -43,29 +38,6 @@ class GeoJsonContent extends \JsonContent {
 			&& $json->type === 'FeatureCollection'
 			&& property_exists( $json, 'features' )
 			&& is_array( $json->features );
-	}
-
-	protected function fillParserOutput( Title $title, $revId, ParserOptions $options,
-		$generateHtml, ParserOutput &$output ) {
-
-		if ( !$generateHtml || !$this->isValid() ) {
-			$output->setText( '' );
-			return;
-		}
-
-		$this->addMapHtmlToOutput( $output );
-
-		$this->storeSemanticValues( $title, $output );
-	}
-
-	private function addMapHtmlToOutput( ParserOutput $output ) {
-		( GeoJsonMapPageUi::forExistingPage( $this->beautifyJSON() ) )->addToOutput( OutputFacade::newFromParserOutput( $output ) );
-	}
-
-	private function storeSemanticValues( Title $title, ParserOutput $output ) {
-		if ( MapsFactory::globalInstance()->smwIntegrationIsEnabled() ) {
-			MapsFactory::globalInstance()->newSemanticGeoJsonStore( $output, $title )->storeGeoJson( $this->mText );
-		}
 	}
 
 }

--- a/src/GeoJsonPages/GeoJsonContentHandler.php
+++ b/src/GeoJsonPages/GeoJsonContentHandler.php
@@ -4,6 +4,12 @@ declare( strict_types = 1 );
 
 namespace Maps\GeoJsonPages;
 
+use Content;
+use Maps\MapsFactory;
+use Maps\Presentation\OutputFacade;
+use MediaWiki\Content\Renderer\ContentParseParams;
+use ParserOutput;
+
 class GeoJsonContentHandler extends \JsonContentHandler {
 
 	public function __construct( $modelId = GeoJsonContent::CONTENT_MODEL_ID ) {
@@ -11,11 +17,36 @@ class GeoJsonContentHandler extends \JsonContentHandler {
 	}
 
 	protected function getContentClass(): string {
-		return GeoJsonContent::class;
+		return version_compare( MW_VERSION, '1.38', '<' ) ? GeoJsonLegacyContent::class : GeoJsonContent::class;
 	}
 
 	public function makeEmptyContent(): GeoJsonContent {
-		return new GeoJsonContent( GeoJsonContent::newEmptyContentString() );
+		$class = $this->getContentClass();
+		return new $class( $class::newEmptyContentString() );
 	}
 
+	/**
+	 * @inheritdoc
+	 */
+	protected function fillParserOutput(
+		Content $content,
+		ContentParseParams $cpoParams,
+		ParserOutput &$parserOutput
+	) {
+		'@phan-var GeoJsonContent $content';
+
+		if ( !$cpoParams->getGenerateHtml() || !$content->isValid() ) {
+			$parserOutput->setText( '' );
+			return;
+		}
+
+		GeoJsonMapPageUi::forExistingPage( $content->beautifyJSON() )
+			->addToOutput( OutputFacade::newFromParserOutput( $parserOutput ) );
+
+		if ( MapsFactory::globalInstance()->smwIntegrationIsEnabled() && $parserOutput->hasText() ) {
+			MapsFactory::globalInstance()
+				->newSemanticGeoJsonStore( $parserOutput, $cpoParams->getPage() )
+				->storeGeoJson( $parserOutput->getRawText() );
+		}
+	}
 }

--- a/src/GeoJsonPages/GeoJsonLegacyContent.php
+++ b/src/GeoJsonPages/GeoJsonLegacyContent.php
@@ -1,0 +1,41 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Maps\GeoJsonPages;
+
+use Maps\GeoJsonPages\GeoJsonContent as GeoJsonPagesGeoJsonContent;
+use Maps\MapsFactory;
+use Maps\Presentation\OutputFacade;
+use ParserOptions;
+use ParserOutput;
+use Title;
+
+/**
+ * @deprecated This class should be removed when Maps drops support for MediaWiki 1.37.
+ */
+class GeoJsonLegacyContent extends GeoJsonPagesGeoJsonContent {
+
+	protected function fillParserOutput( Title $title, $revId, ParserOptions $options,
+		$generateHtml, ParserOutput &$output ) {
+
+		if ( !$generateHtml || !$this->isValid() ) {
+			$output->setText( '' );
+			return;
+		}
+
+		$this->addMapHtmlToOutput( $output );
+
+		$this->storeSemanticValues( $title, $output );
+	}
+
+	private function addMapHtmlToOutput( ParserOutput $output ) {
+		( GeoJsonMapPageUi::forExistingPage( $this->beautifyJSON() ) )->addToOutput( OutputFacade::newFromParserOutput( $output ) );
+	}
+
+	private function storeSemanticValues( Title $title, ParserOutput $output ) {
+		if ( MapsFactory::globalInstance()->smwIntegrationIsEnabled() ) {
+			MapsFactory::globalInstance()->newSemanticGeoJsonStore( $output, $title )->storeGeoJson( $this->mText );
+		}
+	}
+}

--- a/src/GeoJsonPages/GeoJsonMapPageUi.php
+++ b/src/GeoJsonPages/GeoJsonMapPageUi.php
@@ -20,7 +20,7 @@ class GeoJsonMapPageUi {
 	}
 
 	public function addToOutput( OutputFacade $output ) {
-		$output->addHTML( $this->getJavascript() . $this->getHtml() );
+		$output->addHtml( $this->getJavascript() . $this->getHtml() );
 		$output->addModules( 'ext.maps.geojson.page' );
 	}
 

--- a/src/Presentation/OutputFacade.php
+++ b/src/Presentation/OutputFacade.php
@@ -30,7 +30,9 @@ class OutputFacade {
 		}
 
 		if ( $this->parserOutput !== null ) {
-			$this->parserOutput->setText( $this->parserOutput->getRawText() . $html );
+			// Append the HTML to any existing text.
+			$existingText = $this->parserOutput->hasText() ? $this->parserOutput->getRawText() : '';
+			$this->parserOutput->setText( $existingText . $html );
 		}
 	}
 


### PR DESCRIPTION
Move the HTML-setting into the ContentHandler instead of the Content.

Bug: #698