### PR TITLE
Fix "must be an instance of ParserOutput, null given"

### DIFF
--- a/src/Map/CargoFormat/CargoFormat.php
+++ b/src/Map/CargoFormat/CargoFormat.php
@@ -11,7 +11,7 @@ class CargoFormat extends CargoDisplayFormat {
 
 	private \ParserOutput $parserOutput;
 
-	public function __construct( $output, $parserOutput ) {
+	public function __construct( \OutputPage $output, $parserOutput ) {
 		parent::__construct( $output, $parserOutput );
 		$this->parserOutput = $parserOutput;
 	}

--- a/src/Map/CargoFormat/CargoFormat.php
+++ b/src/Map/CargoFormat/CargoFormat.php
@@ -11,7 +11,7 @@ class CargoFormat extends CargoDisplayFormat {
 
 	private \ParserOutput $parserOutput;
 
-	public function __construct( \OutputPage $output, $parserOutput ) {
+	public function __construct( $output, $parser = null ) {
 		parent::__construct( $output, $parserOutput );
 		$this->parserOutput = $parserOutput;
 	}

--- a/src/Map/CargoFormat/CargoFormat.php
+++ b/src/Map/CargoFormat/CargoFormat.php
@@ -11,7 +11,7 @@ class CargoFormat extends CargoDisplayFormat {
 
 	private \ParserOutput $parserOutput;
 
-	public function __construct( \OutputPage $output, \ParserOutput $parserOutput ) {
+	public function __construct( $output, $parserOutput ) {
 		parent::__construct( $output, $parserOutput );
 		$this->parserOutput = $parserOutput;
 	}
@@ -33,8 +33,10 @@ class CargoFormat extends CargoDisplayFormat {
 			$displayParams
 		);
 
-		$this->parserOutput->addHeadItem( $mapOutput->getHeadItems() );
-		$this->parserOutput->addModules( $mapOutput->getResourceModules() );
+		if ( $this->parserOutput ) {
+			$this->parserOutput->addHeadItem( $mapOutput->getHeadItems() );
+			$this->parserOutput->addModules( $mapOutput->getResourceModules() );
+		}
 
 		return $mapOutput->getHtml();
 	}


### PR DESCRIPTION
```
Argument 2 passed to Maps\Map\CargoFormat\CargoFormat::__construct() must be an instance of ParserOutput, null given, called in /srv/mediawiki/w/extensions/Cargo/includes/CargoQueryDisplayer.php on line 90
```