### PR TITLE
Remove MW version check from MapsRegistration

### DIFF
--- a/src/MapsRegistration.php
+++ b/src/MapsRegistration.php
@@ -29,13 +29,6 @@ class MapsRegistration {
 				throw new Exception( 'Maps needs to be installed via Composer.' );
 			}
 
-			if ( version_compare( $GLOBALS['wgVersion'], '1.35c', '<' ) ) {
-				throw new Exception(
-					'This version of Maps requires MediaWiki 1.35 or above; upgrade MediaWiki or use an older version of Maps.'
-					. ' More information at https://github.com/JeroenDeDauw/Maps/blob/master/INSTALL.md'
-				);
-			}
-
 			( new MapsSetup() )->setup();
 
 			return true;


### PR DESCRIPTION
The extension can only be activated with wfLoadExtension which performs the required version check based on the data in extension.json, so there's no need for this additional check here.

This also refered to version "1.35c", which has never existed.