### PR TITLE
Consistently use egMapsScriptPath for front-end asset paths

### DIFF
--- a/resources/GoogleMaps/jquery.googlemap.js
+++ b/resources/GoogleMaps/jquery.googlemap.js
@@ -101,7 +101,7 @@
 			if (markerData.visitedicon !== '') {
 				if(markerData.visitedicon === 'on'){
 					//when keyword 'on' is set, set visitedicon to a default official marker
-					markerOptions.visitedicon = mw.config.get('wgScriptPath')+'/extensions/Maps/resources/GoogleMaps/img/blue-dot.png';
+					markerOptions.visitedicon = mw.config.get( 'egMapsScriptPath' )+'/resources/GoogleMaps/img/blue-dot.png';
 				}else{
 					markerOptions.visitedicon = markerData.visitedicon;
 				}
@@ -439,8 +439,8 @@
 				this.markercluster = null;
 			}
 			this.markercluster = new MarkerClusterer( this.map, this.markers, {
-				imagePath: mw.config.get( 'wgScriptPath' ) +
-				'/extensions/Maps/resources/leaflet/cluster/m',
+				imagePath: mw.config.get( 'egMapsScriptPath' ) +
+				'/resources/leaflet/cluster/m',
 				gridSize: this.options.clustergridsize,
 				maxZoom: this.options.clustermaxzoom,
 				zoomOnClick: this.options.clusterzoomonclick,

--- a/src/MapsHooks.php
+++ b/src/MapsHooks.php
@@ -62,7 +62,10 @@ final class MapsHooks {
 	 * @return boolean true in all cases
 	 */
 	public static function onMakeGlobalVariablesScript( array &$vars ) {
-		$vars['egMapsScriptPath'] = $GLOBALS['wgScriptPath'] . '/extensions/Maps/'; // TODO: wgExtensionDirectory?
+		$config = MediaWikiServices::getInstance()->getMainConfig();
+		$extensionAssetsPath = $config->get( 'ExtensionAssetsPath' );
+
+		$vars['egMapsScriptPath'] = $extensionAssetsPath . '/Maps/';
 		$vars['egMapsDebugJS'] = $GLOBALS['egMapsDebugJS'];
 		$vars['egMapsAvailableServices'] = $GLOBALS['egMapsAvailableServices'];
 		$vars['egMapsLeafletLayersApiKeys'] = $GLOBALS['egMapsLeafletLayersApiKeys'];


### PR DESCRIPTION
Ensure all front-end asset paths use `egMapsScriptPath` as the base rather than building an asset path themselves. Derive `egMapsScriptPath` from the `ExtensionAssetsPath` config variable, since deployments may use this config var to customize the asset path for e.g. multi-version MediaWiki deployments.