### PR TITLE
FIX(leaflet): Load only one base layer at a time

### DIFF
--- a/resources/leaflet/jquery.leaflet.js
+++ b/resources/leaflet/jquery.leaflet.js
@@ -280,10 +280,11 @@
 			return layers;
 		};
 
-		this.addBaseLayersToMap = function(layers) {
-			layers.forEach(function(layerObject, layerName) {
-				layerObject.addTo(_this.map);
-			});
+		this.addBaseLayerToMap = function(layers) {
+			if (layers.size > 0) {
+				let layerObjects = Array.from(layers.values());
+				layerObjects.pop().addTo(_this.map);
+			}
 		};
 
 		this.addOverlays = function() {
@@ -298,7 +299,7 @@
 
 		this.addLayersAndOverlays = function() {
 			let layers = this.getBaseLayers();
-			this.addBaseLayersToMap(layers);
+			this.addBaseLayerToMap(layers);
 
 			let overlays = this.addOverlays();
 


### PR DESCRIPTION
Previously, leaflet maps would initially load and display *all* available base layers at once. This caused performance issues on clients with slow connections or limited memory.

The function that adds base layers to the map has been changed so that it only initially adds the last available base layer. This solves the problem while making sure the initially visible base layer stays the same (previously, although all base layers were loaded only the last layer was shown on top and was visible to the user).