### PR TITLE
Remove usage of wgHooks global variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           php tests/phpunit/phpunit.php -c extensions/Maps --coverage-clover coverage.xml
           bash <(curl -s https://codecov.io/bash)
-        if: matrix.mw == 'REL1_37'
+        if: matrix.mw == 'REL1_38'
 
 
 #  Psalm:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
       - name: Install MediaWiki
         if: steps.cache-mediawiki.outputs.cache-hit != 'true'
         working-directory: ~
-        run: bash EarlyCopy/.github/workflows/installMediaWiki.sh REL1_37 Maps
+        run: bash EarlyCopy/.github/workflows/installMediaWiki.sh REL1_39 Maps
 
       - uses: actions/checkout@v2
         with:
@@ -242,7 +242,7 @@ jobs:
       - name: Install MediaWiki
         if: steps.cache-mediawiki.outputs.cache-hit != 'true'
         working-directory: ~
-        run: bash EarlyCopy/.github/workflows/installMediaWiki.sh REL1_37 Maps
+        run: bash EarlyCopy/.github/workflows/installMediaWiki.sh REL1_39 Maps
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
         with:
           path: mediawiki/extensions/Maps
 
+      - name: Composer allow-plugins
+        run: composer config --no-plugins allow-plugins.composer/installers true
+
       - run: composer update
 
       - name: Run PHPUnit

--- a/src/MapsRegistration.php
+++ b/src/MapsRegistration.php
@@ -21,7 +21,9 @@ class MapsRegistration {
 			define( 'NS_GEO_JSON_TALK', 421 );
 		}
 
-		$GLOBALS['wgHooks']['SMW::Settings::BeforeInitializationComplete'][] = 'Maps\MapsHooks::addSmwSettings';
+		$hooks = [];
+		$hooks['SMW::Settings::BeforeInitializationComplete'][] = 'Maps\MapsHooks::addSmwSettings';
+		MapsHooks::registerHookHandlers( $hooks );
 
 		$GLOBALS['wgExtensionFunctions'][] = function () {
 			// Only initialize the extension when all dependencies are present.

--- a/src/MapsSetup.php
+++ b/src/MapsSetup.php
@@ -60,9 +60,12 @@ class MapsSetup {
 	}
 
 	private function registerParserHooks() {
-		$GLOBALS['wgHooks']['ParserFirstCallInit'][] = function ( Parser $parser ) {
+		$hooks = [];
+		$hooks['ParserFirstCallInit'][] = function ( Parser $parser ) {
 			MapsFactory::globalInstance()->newParserHookSetup( $parser )->registerParserHooks();
 		};
+
+		MapsHooks::registerHookHandlers( $hooks );
 	}
 
 	private function registerParameterTypes() {
@@ -104,18 +107,20 @@ class MapsSetup {
 	}
 
 	private function registerHooks() {
-		$GLOBALS['wgHooks']['AdminLinks'][] = 'Maps\MapsHooks::addToAdminLinks';
-		$GLOBALS['wgHooks']['MakeGlobalVariablesScript'][] = 'Maps\MapsHooks::onMakeGlobalVariablesScript';
-		$GLOBALS['wgHooks']['SkinTemplateNavigation::Universal'][] = 'Maps\MapsHooks::onSkinTemplateNavigationUniversal';
-		$GLOBALS['wgHooks']['BeforeDisplayNoArticleText'][] = 'Maps\MapsHooks::onBeforeDisplayNoArticleText';
-		$GLOBALS['wgHooks']['ShowMissingArticle'][] = 'Maps\MapsHooks::onShowMissingArticle';
-		$GLOBALS['wgHooks']['ListDefinedTags'][] = 'Maps\MapsHooks::onRegisterTags';
-		$GLOBALS['wgHooks']['ChangeTagsListActive'][] = 'Maps\MapsHooks::onRegisterTags';
-		$GLOBALS['wgHooks']['ChangeTagsAllowedAdd'][] = 'Maps\MapsHooks::onChangeTagsAllowedAdd';
+		$hooks = [];
+		$hooks['AdminLinks'][] = 'Maps\MapsHooks::addToAdminLinks';
+		$hooks['MakeGlobalVariablesScript'][] = 'Maps\MapsHooks::onMakeGlobalVariablesScript';
+		$hooks['SkinTemplateNavigation::Universal'][] = 'Maps\MapsHooks::onSkinTemplateNavigationUniversal';
+		$hooks['BeforeDisplayNoArticleText'][] = 'Maps\MapsHooks::onBeforeDisplayNoArticleText';
+		$hooks['ShowMissingArticle'][] = 'Maps\MapsHooks::onShowMissingArticle';
+		$hooks['ListDefinedTags'][] = 'Maps\MapsHooks::onRegisterTags';
+		$hooks['ChangeTagsListActive'][] = 'Maps\MapsHooks::onRegisterTags';
+		$hooks['ChangeTagsAllowedAdd'][] = 'Maps\MapsHooks::onChangeTagsAllowedAdd';
 
-		$GLOBALS['wgHooks']['CargoSetFormatClasses'][] = function( array &$formatClasses ) {
+		$hooks['CargoSetFormatClasses'][] = function( array &$formatClasses ) {
 			$formatClasses['map'] = CargoFormat::class;
 		};
-	}
 
+		MapsHooks::registerHookHandlers( $hooks );
+	}
 }

--- a/src/SemanticMapsSetup.php
+++ b/src/SemanticMapsSetup.php
@@ -24,7 +24,8 @@ class SemanticMapsSetup {
 
 	public function initExtension() {
 		// Hook for initializing the Geographical Data types.
-		$GLOBALS['wgHooks']['SMW::DataType::initTypes'][] = function() {
+		$hooks = [];
+		$hooks['SMW::DataType::initTypes'][] = function() {
 			DataTypeRegistry::getInstance()->registerDatatype(
 				'_geo',
 				CoordinateValue::class,
@@ -35,7 +36,8 @@ class SemanticMapsSetup {
 		};
 
 		// Hook for defining the default query printer for queries that ask for geographical coordinates.
-		$GLOBALS['wgHooks']['SMWResultFormat'][] = 'Maps\MapsHooks::addGeoCoordsDefaultFormat';
+		$hooks['SMWResultFormat'][] = 'Maps\MapsHooks::addGeoCoordsDefaultFormat';
+		MapsHooks::registerHookHandlers( $hooks );
 
 		$this->registerGoogleMaps();
 		$this->registerLeaflet();


### PR DESCRIPTION
PHP Deprecated:  Accessing $wgHooks directly is deprecated, use 
HookContainer::getHandlers() or HookContainer::register() instead

Bug: https://phabricator.wikimedia.org/T332687