### PR TITLE
HookRunner: Use MediaWikiServices instance if available

### DIFF
--- a/src/MapsHooks.php
+++ b/src/MapsHooks.php
@@ -176,7 +176,7 @@ final class MapsHooks {
 	}
 
 	public static function registerHookHandlers( array $hooks ): void {
-		if ( defined( 'MW_PHPUNIT_TEST' ) && MediaWikiServices::hasInstance() ) {
+		if ( MediaWikiServices::hasInstance() ) {
 			// When called from a test case's setUp() method,
 			// we can use HookContainer, but we cannot use SettingsBuilder.
 			$hookContainer = MediaWikiServices::getInstance()->getHookContainer();


### PR DESCRIPTION
This fixes the issue:

MediaWiki\Settings\SettingsBuilderException:
MediaWiki\Settings\SettingsBuilder::registerHookHandlers not supported in operation stage.

This is needed because the extension uses wgExtensionFunctions which does not appear to be working well with the SettingsBuilder

Bug: https://phabricator.wikimedia.org/T332687
Change-Id: I02c8a92ddc35cb55a488f5d9c8dbc41bc82b96a0