### PR TITLE
fix: ensure catch syntax compatibility with PHP 7.x

### DIFF
--- a/src/GeoJsonPages/Semantic/SubObjectBuilder.php
+++ b/src/GeoJsonPages/Semantic/SubObjectBuilder.php
@@ -22,7 +22,7 @@ class SubObjectBuilder {
 		try {
 			$geoJson = GeoJson::jsonUnserialize( $json );
 		}
-		catch ( UnserializationException ) {
+		catch ( UnserializationException $e ) {
 			// TODO: log warning
 			return [];
 		}


### PR DESCRIPTION
This fixes the bug described in https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/5590 by assigning the caught exception to a variable in `SubObjectBuilder.php`.
This ensures compatibility with PHP versions 7.x as support for omitting the variable starts with 8.0.0.