### PR TITLE
Fix for VusualEditor

### DIFF
--- a/src/SemanticMW/QueryHandler.php
+++ b/src/SemanticMW/QueryHandler.php
@@ -468,7 +468,13 @@ class QueryHandler {
 	}
 
 	private function getParser(): \Parser {
-		return MediaWikiServices::getInstance()->getParser();
+		$user = \RequestContext::getMain()->getUser();
+		$parser = MediaWikiServices::getInstance()->getParser();
+		if ( !$parser->getOptions() ) {
+			$parser->setOptions( new \ParserOptions( $user ) );
+		}
+		$parser->clearState();
+		return $parser;
 	}
 
 	/**


### PR DESCRIPTION
It throws the error in MW 1.39.6 when you try to edit a page using VE with a map.

The error message:
```
Exception caught: Call to a member function getMaxIncludeSize() on null","errorclass":"Error","trace":
"Error at /var/www/mediawiki/w/includes/parser/Parser.php(2935)
from /var/www/mediawiki/w/includes/parser/Parser.php(2935)
#0 /var/www/mediawiki/w/includes/parser/Parser.php(1609): Parser->replaceVariables()
#1 /var/www/mediawiki/w/includes/parser/Parser.php(881): Parser->internalParse()
#2 /var/www/mediawiki/w/includes/parser/Parser.php(905): Parser->recursiveTagParse()
#3 /var/www/mediawiki/w/extensions/Maps/src/SemanticMW/QueryHandler.php(442): Parser->recursiveTagParseFully()
#4 /var/www/mediawiki/w/extensions/Maps/src/SemanticMW/QueryHandler.php(431): Maps\\SemanticMW\\QueryHandler->buildPopupText()
#5 /var/www/mediawiki/w/extensions/Maps/src/SemanticMW/QueryHandler.php(159): Maps\\SemanticMW\\QueryHandler->buildLocationsForPage()
#6 /var/www/mediawiki/w/extensions/Maps/src/SemanticMW/QueryHandler.php(146): Maps\\SemanticMW\\QueryHandler->handlePageResult()
#7 /var/www/mediawiki/w/extensions/Maps/src/Map/SemanticFormat/MapPrinter.php(262): Maps\\SemanticMW\\QueryHandler->getLocations()
#8 /var/www/mediawiki/w/extensions/Maps/src/Map/SemanticFormat/MapPrinter.php(199): Maps\\Map\\SemanticFormat\\MapPrinter->getJsonForLocations()
#9 /var/www/mediawiki/w/extensions/Maps/src/Map/SemanticFormat/MapPrinter.php(111): Maps\\Map\\SemanticFormat\\MapPrinter->handleMarkerData()
#10 /var/www/mediawiki/w/extensions/SemanticMediaWiki/src/Query/ResultPrinters/ResultPrinter.php(339): Maps\\Map\\SemanticFormat\\MapPrinter->getResultText()
#11 /var/www/mediawiki/w/extensions/SemanticMediaWiki/src/Query/ResultPrinters/ResultPrinter.php(304): SMW\\Query\\ResultPrinters\\ResultPrinter->buildResult()
#12 /var/www/mediawiki/w/extensions/SemanticMediaWiki/includes/query/SMW_QueryProcessor.php(348): SMW\\Query\\ResultPrinters\\ResultPrinter->getResult()
#13 /var/www/mediawiki/w/extensions/SemanticMediaWiki/src/ParserFunctions/AskParserFunction.php(370): SMWQueryProcessor::getResultFromQuery()
#14 /var/www/mediawiki/w/extensions/SemanticMediaWiki/src/ParserFunctions/AskParserFunction.php(202): SMW\\ParserFunctions\\AskParserFunction->doFetchResultsFromFunctionParameters()
#15 /var/www/mediawiki/w/extensions/SemanticMediaWiki/src/ParserFunctionFactory.php(402): SMW\\ParserFunctions\\AskParserFunction->parse()
#16 /var/www/mediawiki/w/includes/parser/Parser.php(3437): SMW\\ParserFunctionFactory->SMW\\{closure}()
#17 /var/www/mediawiki/w/includes/parser/Parser.php(3122): Parser->callParserFunction()
#18 /var/www/mediawiki/w/includes/parser/PPFrame_Hash.php(275): Parser->braceSubstitution()
#19 /var/www/mediawiki/w/includes/parser/Parser.php(3313): PPFrame_Hash->expand()
#20 /var/www/mediawiki/w/includes/parser/PPFrame_Hash.php(275): Parser->braceSubstitution()
#21 /var/www/mediawiki/w/includes/parser/Parser.php(2951): PPFrame_Hash->expand()
#22 /var/www/mediawiki/w/includes/parser/Parsoid/Config/DataAccess.php(377): Parser->replaceVariables()
#23 /var/www/mediawiki/w/vendor/wikimedia/parsoid/src/Wikitext/Wikitext.php(43): MediaWiki\\Parser\\Parsoid\\Config\\DataAccess->preprocessWikitext()
#24 /var/www/mediawiki/w/vendor/wikimedia/parsoid/src/Wt2Html/TT/TemplateHandler.php(1108): Wikimedia\\Parsoid\\Wikitext\\Wikitext::preprocess()
#25 /var/www/mediawiki/w/vendor/wikimedia/parsoid/src/Wt2Html/TT/TemplateHandler.php(1151): Wikimedia\\Parsoid\\Wt2Html\\TT\\TemplateHandler->expandTemplate()
#26 /var/www/mediawiki/w/vendor/wikimedia/parsoid/src/Wt2Html/TT/TemplateHandler.php(1196): Wikimedia\\Parsoid\\Wt2Html\\TT\\TemplateHandler->onTemplate()
#27 /var/www/mediawiki/w/vendor/wikimedia/parsoid/src/Wt2Html/TT/TokenHandler.php(150): Wikimedia\\Parsoid\\Wt2Html\\TT\\TemplateHandler->onTag()
#28 /var/www/mediawiki/w/vendor/wikimedia/parsoid/src/Wt2Html/TokenTransformManager.php(132): Wikimedia\\Parsoid\\Wt2Html\\TT\\TokenHandler->process()
#29 /var/www/mediawiki/w/vendor/wikimedia/parsoid/src/Wt2Html/TokenTransformManager.php(195): Wikimedia\\Parsoid\\Wt2Html\\TokenTransformManager->processChunk()
#30 /var/www/mediawiki/w/vendor/wikimedia/parsoid/src/Wt2Html/TokenTransformManager.php(193): Wikimedia\\Parsoid\\Wt2Html\\TokenTransformManager->processChunkily()
#31 /var/www/mediawiki/w/vendor/wikimedia/parsoid/src/Wt2Html/TreeBuilder/TreeBuilderStage.php(487): Wikimedia\\Parsoid\\Wt2Html\\TokenTransformManager->processChunkily()
#32 [internal function]: Wikimedia\\Parsoid\\Wt2Html\\TreeBuilder\\TreeBuilderStage->processChunkily()
#33 /var/www/mediawiki/w/vendor/wikimedia/parsoid/src/Wt2Html/DOMPostProcessor.php(904): Generator->current()
#34 /var/www/mediawiki/w/vendor/wikimedia/parsoid/src/Wt2Html/ParserPipeline.php(180): Wikimedia\\Parsoid\\Wt2Html\\DOMPostProcessor->processChunkily()
#35 /var/www/mediawiki/w/vendor/wikimedia/parsoid/src/Wt2Html/ParserPipelineFactory.php(308): Wikimedia\\Parsoid\\Wt2Html\\ParserPipeline->parseChunkily()
#36 /var/www/mediawiki/w/vendor/wikimedia/parsoid/src/Wikitext/ContentModelHandler.php(123): Wikimedia\\Parsoid\\Wt2Html\\ParserPipelineFactory->parse()
#37 /var/www/mediawiki/w/vendor/wikimedia/parsoid/src/Parsoid.php(172): Wikimedia\\Parsoid\\Wikitext\\ContentModelHandler->toDOM()
#38 /var/www/mediawiki/w/vendor/wikimedia/parsoid/src/Parsoid.php(210): Wikimedia\\Parsoid\\Parsoid->parseWikitext()
#39 /var/www/mediawiki/w/extensions/VisualEditor/includes/VisualEditorParsoidClient.php(123): Wikimedia\\Parsoid\\Parsoid->wikitext2html()
#40 /var/www/mediawiki/w/extensions/VisualEditor/includes/ParsoidHelper.php(224): MediaWiki\\Extension\\VisualEditor\\VisualEditorParsoidClient->getPageHtml()
#41 /var/www/mediawiki/w/extensions/VisualEditor/includes/ApiParsoidTrait.php(134): MediaWiki\\Extension\\VisualEditor\\ParsoidHelper->requestRestbasePageHtml()
#42 /var/www/mediawiki/w/extensions/VisualEditor/includes/ApiVisualEditor.php(279): MediaWiki\\Extension\\VisualEditor\\ApiVisualEditor->requestRestbasePageHtml()
#43 /var/www/mediawiki/w/includes/api/ApiMain.php(1900): MediaWiki\\Extension\\VisualEditor\\ApiVisualEditor->execute()
#44 /var/www/mediawiki/w/includes/api/ApiMain.php(875): ApiMain->executeAction()
#45 /var/www/mediawiki/w/includes/api/ApiMain.php(846): ApiMain->executeActionWithErrorHandling()
#46 /var/www/mediawiki/w/api.php(90): ApiMain->execute()
#47 /var/www/mediawiki/w/api.php(45): wfApiMain()
#48 {main}
```