### PR TITLE
Do not call $parser->clearState() when parser options exist

### DIFF
--- a/src/SemanticMW/QueryHandler.php
+++ b/src/SemanticMW/QueryHandler.php
@@ -468,12 +468,12 @@ class QueryHandler {
 	}
 
 	private function getParser(): \Parser {
-		$user = \RequestContext::getMain()->getUser();
 		$parser = MediaWikiServices::getInstance()->getParser();
 		if ( !$parser->getOptions() ) {
+			$user = \RequestContext::getMain()->getUser();
 			$parser->setOptions( new \ParserOptions( $user ) );
+			$parser->clearState();
 		}
-		$parser->clearState();
 		return $parser;
 	}
 


### PR DESCRIPTION
The previous patch breaks widgets (and most likely other things) because it calls $parser->clearState() every time.
