### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,31 +9,43 @@ on:
 jobs:
   test:
     name: "PHPUnit: MW ${{ matrix.mw }}, PHP ${{ matrix.php }}"
+    continue-on-error: ${{ matrix.experimental }}
 
     strategy:
       matrix:
         include:
           - mw: 'REL1_35'
             php: 7.4
+            experimental: false
           - mw: 'REL1_36'
             php: 7.4
+            experimental: false
           - mw: 'REL1_37'
             php: 7.4
+            experimental: false
           - mw: 'REL1_38'
             php: 8.0
+            experimental: false
           - mw: 'REL1_39'
             php: 8.1
+            experimental: false
           - mw: 'REL1_40'
             php: 8.1
+            experimental: false
           - mw: 'REL1_41'
             php: 8.2
+            experimental: false
           - mw: 'REL1_42'
             php: 8.2
+            experimental: false
           - mw: 'REL1_43'
-            php: 8.2
+            php: 8.3
+            experimental: false
+          - mw: 'master'
+            php: 8.4
+            experimental: true
 
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.php == 8.3 }}
 
     defaults:
       run:


### PR DESCRIPTION
- Use experimental flags like the other CIs
- Add PHP 8.4 and master
- Use PHP 8.3 for MW 1.43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced our automated testing process with refined error handling and additional test configurations for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->