### PR TITLE
Use data-mw-maps-mapdata attribute for mapdata

### DIFF
--- a/resources/GoogleMaps/ext.maps.googlemaps3.js
+++ b/resources/GoogleMaps/ext.maps.googlemaps3.js
@@ -8,7 +8,7 @@ window.mapsGoogleList = [];
 			$content.find( '.maps-googlemaps3' ).each( function() {
 				var $this = $( this );
 				window.mapsGoogleList.push(
-					$this.googlemaps( $this.data( 'mw-maps-mapdata' ) )
+					$this.googlemaps( $this.data( 'mw-maps-mapdata' ) || {} )
 				);
 			} );
 		}

--- a/resources/GoogleMaps/ext.maps.googlemaps3.js
+++ b/resources/GoogleMaps/ext.maps.googlemaps3.js
@@ -8,7 +8,7 @@ window.mapsGoogleList = [];
 			$content.find( '.maps-googlemaps3' ).each( function() {
 				var $this = $( this );
 				window.mapsGoogleList.push(
-					$this.googlemaps( JSON.parse( $this.find( 'div.mapdata' ).text() ) )
+					$this.googlemaps( $this.data( 'mw-maps-mapdata' ) )
 				);
 			} );
 		}

--- a/resources/leaflet/LeafletLoader.js
+++ b/resources/leaflet/LeafletLoader.js
@@ -11,9 +11,7 @@ window.mapsLeafletList = [];
 
 			$this.data( 'initialized', true );
 
-			let jqueryMap = $this.leafletmaps(
-				$this.data( 'mw-maps-mapdata' )
-			);
+			let jqueryMap = $this.leafletmaps( $this.data( 'mw-maps-mapdata' ) || {} );
 
 			jqueryMap.setup();
 

--- a/resources/leaflet/LeafletLoader.js
+++ b/resources/leaflet/LeafletLoader.js
@@ -12,7 +12,7 @@ window.mapsLeafletList = [];
 			$this.data( 'initialized', true );
 
 			let jqueryMap = $this.leafletmaps(
-				JSON.parse( $this.find( 'div.mapdata' ).text() )
+				$this.data( 'mw-maps-mapdata' )
 			);
 
 			jqueryMap.setup();

--- a/src/Map/MapHtmlBuilder.php
+++ b/src/Map/MapHtmlBuilder.php
@@ -23,7 +23,8 @@ class MapHtmlBuilder {
 			[
 				'id' => $mapId,
 				'style' => "width: {$json['width']}; height: {$json['height']}; background-color: #eeeeee; overflow: hidden;",
-				'class' => 'maps-map maps-' . $serviceName
+				'class' => 'maps-map maps-' . $serviceName,
+				'data-mw-maps-mapdata' => FormatJson::encode( $json )
 			],
 			Html::element(
 				'div',
@@ -31,11 +32,6 @@ class MapHtmlBuilder {
 					'class' => 'maps-loading-message'
 				],
 				wfMessage( 'maps-loading-map' )->inContentLanguage()->text()
-			)
-			. Html::element(
-				'div',
-				[ 'style' => 'display:none', 'class' => 'mapdata' ],
-				FormatJson::encode( $json )
 			)
 		);
 	}

--- a/src/MapsRegistration.php
+++ b/src/MapsRegistration.php
@@ -26,11 +26,6 @@ class MapsRegistration {
 		MapsHooks::registerHookHandlers( $hooks );
 
 		$GLOBALS['wgExtensionFunctions'][] = function () {
-			// Only initialize the extension when all dependencies are present.
-			if ( !defined( 'Validator_VERSION' ) ) {
-				throw new Exception( 'Maps needs to be installed via Composer.' );
-			}
-
 			( new MapsSetup() )->setup();
 
 			return true;

--- a/tests/Integration/Parser/DisplayMapTest.php
+++ b/tests/Integration/Parser/DisplayMapTest.php
@@ -35,6 +35,10 @@ class DisplayMapTest extends TestCase {
 		);
 	}
 
+	private function assertStringContainsData( string $expected, string $html ): void {
+		$this->assertStringContainsString( htmlspecialchars( $expected ), $html );
+	}
+
 	private function parse( string $textToParse ): string {
 		return TestFactory::newInstance()->parse( $textToParse );
 	}
@@ -47,7 +51,7 @@ class DisplayMapTest extends TestCase {
 	}
 
 	public function testSingleCoordinatesAreIncluded() {
-		$this->assertStringContainsString(
+		$this->assertStringContainsData(
 			'"lat":1,"lon":1',
 			$this->parse( '{{#display_map:1,1}}' )
 		);
@@ -56,12 +60,12 @@ class DisplayMapTest extends TestCase {
 	public function testMultipleCoordinatesAreIncluded() {
 		$result = $this->parse( '{{#display_map:1,1; 4,2}}' );
 
-		$this->assertStringContainsString( '"lat":1,"lon":1', $result );
-		$this->assertStringContainsString( '"lat":4,"lon":2', $result );
+		$this->assertStringContainsData( '"lat":1,"lon":1', $result );
+		$this->assertStringContainsData( '"lat":4,"lon":2', $result );
 	}
 
 	public function testTagIsRendered() {
-		$this->assertStringContainsString(
+		$this->assertStringContainsData(
 			'"lat":1,"lon":1',
 			$this->parse( '<display_map>1,1</display_map>' )
 		);
@@ -75,14 +79,14 @@ class DisplayMapTest extends TestCase {
 	}
 
 	public function testWhenThereAreNoLocations_locationsArrayIsEmpty() {
-		$this->assertStringContainsString(
+		$this->assertStringContainsData(
 			'"locations":[]',
 			$this->parse( '{{#display_map:}}' )
 		);
 	}
 
 	public function testLocationTitleGetsIncluded() {
-		$this->assertStringContainsString(
+		$this->assertStringContainsData(
 			'"title":"title',
 			$this->parse( '{{#display_map:1,1~title}}' )
 		);
@@ -96,28 +100,28 @@ class DisplayMapTest extends TestCase {
 	}
 
 	public function testRectangleDisplay() {
-		$this->assertStringContainsString(
+		$this->assertStringContainsData(
 			'"title":"title',
 			$this->parse( '{{#display_map:rectangles=1,1:2,2~title}}' )
 		);
 	}
 
 	public function testCircleDisplay() {
-		$this->assertStringContainsString(
+		$this->assertStringContainsData(
 			'"title":"title',
 			$this->parse( '{{#display_map:circles=1,1:2~title}}' )
 		);
 	}
 
 	public function testRectangleFillOpacityIsUsed() {
-		$this->assertStringContainsString(
+		$this->assertStringContainsData(
 			'"fillOpacity":"fill opacity"',
 			$this->parse( '{{#display_map:rectangles=1,1:2,2~title~text~color~opacity~thickness~fill color~fill opacity}}' )
 		);
 	}
 
 	public function testRectangleFillColorIsUsed() {
-		$this->assertStringContainsString(
+		$this->assertStringContainsData(
 			'"fillColor":"fill color"',
 			$this->parse( '{{#display_map:rectangles=1,1:2,2~title~text~color~opacity~thickness~fill color~fill opacity}}' )
 		);
@@ -177,7 +181,7 @@ class DisplayMapTest extends TestCase {
 //	}
 
 	public function testWhenIconParameterIsProvidedButEmpty_itIsDefaulted() {
-		$this->assertStringContainsString(
+		$this->assertStringContainsData(
 			'"icon":"","inlineLabel":"Ghent',
 			$this->parse(
 				"{{#display_map:Gent, Belgie~The city Ghent~Ghent is awesome~ ~ ~Ghent}}"
@@ -186,14 +190,14 @@ class DisplayMapTest extends TestCase {
 	}
 
 	public function testWhenLocationHasNoTitleAndText_textFieldIsEmptyString() {
-		$this->assertStringContainsString(
+		$this->assertStringContainsData(
 			'"text":""',
 			$this->parse( '{{#display_map:1,1}}' )
 		);
 	}
 
 	public function testGeoJsonSourceForFile() {
-		$this->assertStringContainsString(
+		$this->assertStringContainsData(
 			'"GeoJsonSource":null,',
 			$this->parse(
 				"{{#display_map:geojson=404}}"
@@ -210,7 +214,7 @@ class DisplayMapTest extends TestCase {
 			] ) )
 		);
 
-		$this->assertStringContainsString(
+		$this->assertStringContainsData(
 			'"GeoJsonSource":"TestPageSource",',
 			$this->parse(
 				"{{#display_map:geojson=TestPageSource}}"

--- a/tests/Integration/Parser/GoogleMapsTest.php
+++ b/tests/Integration/Parser/GoogleMapsTest.php
@@ -12,6 +12,7 @@ class GoogleMapsTest extends TestCase {
 	private function assertStringContainsData( string $expected, string $html ): void {
 		$this->assertStringContainsString( htmlspecialchars( $expected ), $html );
 	}
+
 	private function parse( string $textToParse ): string {
 		return TestFactory::newInstance()->parse( $textToParse );
 	}

--- a/tests/Integration/Parser/GoogleMapsTest.php
+++ b/tests/Integration/Parser/GoogleMapsTest.php
@@ -9,12 +9,15 @@ use PHPUnit\Framework\TestCase;
 
 class GoogleMapsTest extends TestCase {
 
+	private function assertStringContainsData( string $expected, string $html ): void {
+		$this->assertStringContainsString( htmlspecialchars( $expected ), $html );
+	}
 	private function parse( string $textToParse ): string {
 		return TestFactory::newInstance()->parse( $textToParse );
 	}
 
 	public function testGoogleMapsKmlFiltersInvalidFileNames() {
-		$this->assertStringContainsString(
+		$this->assertStringContainsData(
 			'"kml":["ValidFile.kml"],',
 			$this->parse(
 				"{{#google_maps:kml=, ,ValidFile.kml ,}}"
@@ -23,35 +26,35 @@ class GoogleMapsTest extends TestCase {
 	}
 
 	public function testWhenValidZoomIsSpecified_itGetsUsed() {
-		$this->assertStringContainsString(
+		$this->assertStringContainsData(
 			'"zoom":5',
 			$this->parse( '{{#google_maps:1,1|zoom=5}}' )
 		);
 	}
 
 	public function testWhenZoomIsNotSpecifiedAndThereIsOnlyOneLocation_itIsDefaulted() {
-		$this->assertStringContainsString(
+		$this->assertStringContainsData(
 			'"zoom":' . $GLOBALS['egMapsGMaps3Zoom'],
 			$this->parse( '{{#google_maps:1,1}}' )
 		);
 	}
 
 	public function testWhenZoomIsNotSpecifiedAndThereAreMultipleLocations_itIsDefaulted() {
-		$this->assertStringContainsString(
+		$this->assertStringContainsData(
 			'"zoom":false',
 			$this->parse( '{{#google_maps:1,1;2,2}}' )
 		);
 	}
 
 	public function testWhenZoomIsInvalid_itIsDefaulted() {
-		$this->assertStringContainsString(
+		$this->assertStringContainsData(
 			'"zoom":' . $GLOBALS['egMapsGMaps3Zoom'],
 			$this->parse( '{{#google_maps:1,1|zoom=tomato}}' )
 		);
 	}
 
 	public function testInvalidMapTypesGetLeftOut() {
-		$this->assertStringContainsString(
+		$this->assertStringContainsData(
 			'"types":["ROADMAP"]',
 			$this->parse( '{{#google_maps:1,1|types=normal, foobar}}' )
 		);

--- a/tests/Integration/Parser/LeafletTest.php
+++ b/tests/Integration/Parser/LeafletTest.php
@@ -47,10 +47,10 @@ class LeafletTest extends TestCase {
 
 		$html = $this->parse( "{{#leaflet:image layers=MyImage.png}}" );
 
-		$this->assertStringContainsString( '"name":"MyImage.png"', $html );
-		$this->assertStringContainsString( '"url":"/tmp/example/image.png"', $html );
-		$this->assertStringContainsString( '"width":100', $html );
-		$this->assertStringContainsString( '"height":50', $html );
+		$this->assertStringContainsData( '"name":"MyImage.png"', $html );
+		$this->assertStringContainsData( '"url":"/tmp/example/image.png"', $html );
+		$this->assertStringContainsData( '"width":100', $html );
+		$this->assertStringContainsData( '"height":50', $html );
 	}
 
 }

--- a/tests/Integration/Parser/LeafletTest.php
+++ b/tests/Integration/Parser/LeafletTest.php
@@ -15,8 +15,12 @@ class LeafletTest extends TestCase {
 		return TestFactory::newInstance()->parse( $textToParse );
 	}
 
+	private function assertStringContainsData( string $expected, string $html ): void {
+		$this->assertStringContainsString( htmlspecialchars( $expected ), $html );
+	}
+
 	public function testLeafletImageLayersIgnoresNotFoundImages() {
-		$this->assertStringContainsString(
+		$this->assertStringContainsData(
 			'"imageLayers":[]',
 			$this->parse(
 				"{{#leaflet:image layers=404.png}}"
@@ -25,7 +29,7 @@ class LeafletTest extends TestCase {
 	}
 
 	public function testLeafletImageLayersIgnoresImageUrls() {
-		$this->assertStringContainsString(
+		$this->assertStringContainsData(
 			'"imageLayers":[]',
 			$this->parse(
 				"{{#leaflet:image layers=https://user-images.githubusercontent.com/62098559/76514021-3fa9be80-647d-11ea-82ae-715420a5c432.png}}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined map loading by retrieving data directly from HTML attributes instead of parsing text content.
  - Consolidated map data embedding to simplify the integration process, enhancing efficiency and reliability in map displays.
- **Tests**
  - Introduced a new assertion method to enhance HTML string comparisons across multiple test cases, ensuring proper escaping to prevent HTML injection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->