### PR TITLE
Replace SMW removed class aliases

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,7 +6,7 @@ parameters:
 			path: src/MapsFactory.php
 
 		-
-			message: "#^Method Maps\\\\MapsFactory\\:\\:getSmwFactory\\(\\) has invalid return type SMW\\\\ApplicationFactory\\.$#"
+			message: "#^Method Maps\\\\MapsFactory\\:\\:getSmwFactory\\(\\) has invalid return type SMW\\\\Services\\\\ServicesFactory\\.$#"
 			count: 1
 			path: src/MapsFactory.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,7 +11,7 @@ parameters:
 			path: src/MapsFactory.php
 
 		-
-			message: "#^Access to constant PRINT_THIS on an unknown class SMWPrintRequest\\.$#"
+			message: "#^Access to constant PRINT_THIS on an unknown class SMW\\\Query\\\PrintRequest\\.$#"
 			count: 1
 			path: src/MapsHooks.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,7 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Call to static method getInstance\\(\\) on an unknown class SMW\\\\ApplicationFactory\\.$#"
+			message: "#^Call to static method getInstance\\(\\) on an unknown class SMW\\\\Services\\\\ServicesFactory\\.$#"
 			count: 1
 			path: src/MapsFactory.php
 
@@ -11,7 +11,7 @@ parameters:
 			path: src/MapsFactory.php
 
 		-
-			message: "#^Access to constant PRINT_THIS on an unknown class SMW\\\Query\\\PrintRequest\\.$#"
+			message: "#^Access to constant PRINT_THIS on an unknown class SMW\\\\Query\\\\PrintRequest\\.$#"
 			count: 1
 			path: src/MapsHooks.php
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,7 +16,6 @@ parameters:
 		- src/LegacyMapEditor/
 	scanDirectories:
 		- ../../includes
-		- ../../src
 		- ../../tests/phpunit
 		- ../../vendor
 	ignoreErrors:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,6 +16,7 @@ parameters:
 		- src/LegacyMapEditor/
 	scanDirectories:
 		- ../../includes
+		- ../../src
 		- ../../tests/phpunit
 		- ../../vendor
 	ignoreErrors:

--- a/src/MapsFactory.php
+++ b/src/MapsFactory.php
@@ -41,7 +41,7 @@ use Parser;
 use RepoGroup;
 use SimpleCache\Cache\Cache;
 use SimpleCache\Cache\MediaWikiCache;
-use SMW\ApplicationFactory;
+use SMW\Services\ServicesFactory as ApplicationFactory;
 use Title;
 
 /**

--- a/src/MapsHooks.php
+++ b/src/MapsHooks.php
@@ -11,7 +11,7 @@ use Maps\Presentation\OutputFacade;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Settings\SettingsBuilder;
 use SkinTemplate;
-use SMWPrintRequest;
+use SMW\Query\PrintRequest;
 
 /**
  * Static class for hooks handled by the Maps extension.
@@ -128,7 +128,7 @@ final class MapsHooks {
 	 * @since 1.0
 	 *
 	 * @param $format Mixed: The format (string), or false when not set yet
-	 * @param SMWPrintRequest[] $printRequests The print requests made
+	 * @param PrintRequest[] $printRequests The print requests made
 	 *
 	 * @return boolean
 	 */
@@ -144,7 +144,7 @@ final class MapsHooks {
 				// Loop through the print requests to determine their types.
 				foreach ( $printRequests as $printRequest ) {
 					// Skip the first request, as it's the object.
-					if ( $printRequest->getMode() == SMWPrintRequest::PRINT_THIS ) {
+					if ( $printRequest->getMode() == PrintRequest::PRINT_THIS ) {
 						continue;
 					}
 


### PR DESCRIPTION
I missed this spot.

Replace:

* SMWPrintRequest -> SMW\Query\PrintRequest 
* SMW\ApplicationFactory -> SMW\Services\ServicesFactory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved the handling of print requests for greater consistency and reliability.
- **Chores**
	- Updated internal error messaging to provide more accurate diagnostics.
	- Adjusted import statements to reflect changes in class structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->