### PR TITLE
Remove CI for MW 1.35-MW.138

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,18 +14,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - mw: 'REL1_35'
-            php: 7.4
-            experimental: false
-          - mw: 'REL1_36'
-            php: 7.4
-            experimental: false
-          - mw: 'REL1_37'
-            php: 7.4
-            experimental: false
-          - mw: 'REL1_38'
-            php: 8.0
-            experimental: false
           - mw: 'REL1_39'
             php: 8.1
             experimental: false
@@ -95,13 +83,12 @@ jobs:
 
       - name: Run PHPUnit
         run: php tests/phpunit/phpunit.php -c extensions/Maps
-        if: matrix.mw != 'REL1_37'
 
       - name: Run PHPUnit with code coverage
         run: |
           php tests/phpunit/phpunit.php -c extensions/Maps --coverage-clover coverage.xml
           bash <(curl -s https://codecov.io/bash)
-        if: matrix.mw == 'REL1_38'
+        if: matrix.mw == 'REL1_40'
 
 
 #  Psalm:

--- a/extension.json
+++ b/extension.json
@@ -12,9 +12,9 @@
 	"type": "parserhook",
 
 	"requires": {
-		"MediaWiki": ">= 1.35.0",
+		"MediaWiki": ">= 1.39.0",
 		"platform": {
-			"php": ">= 7.4"
+			"php": ">= 8.1"
 		}
 	},
 


### PR DESCRIPTION
These are old and unsupported releases. MW 1.39+ is supported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined automated testing processes to focus on recent platform releases.
  - Adjusted conditions for test execution to improve validation.
  - Updated compatibility requirements by raising the minimum supported MediaWiki version to 1.39 and PHP to 8.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->