### PR TITLE
Use classes namespaced in MW 1.40 after removal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,20 +14,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - mw: 'REL1_35'
-            php: 7.4
-            experimental: false
-          - mw: 'REL1_36'
-            php: 7.4
-            experimental: false
-          - mw: 'REL1_37'
-            php: 7.4
-            experimental: false
-          - mw: 'REL1_38'
-            php: 8.0
-            experimental: false
-          - mw: 'REL1_39'
-            php: 8.1
             experimental: false
           - mw: 'REL1_40'
             php: 8.1
@@ -95,13 +81,13 @@ jobs:
 
       - name: Run PHPUnit
         run: php tests/phpunit/phpunit.php -c extensions/Maps
-        if: matrix.mw != 'REL1_37'
+        if: matrix.mw != 'REL1_43'
 
       - name: Run PHPUnit with code coverage
         run: |
           php tests/phpunit/phpunit.php -c extensions/Maps --coverage-clover coverage.xml
           bash <(curl -s https://codecov.io/bash)
-        if: matrix.mw == 'REL1_38'
+        if: matrix.mw == 'REL1_43'
 
 
 #  Psalm:
@@ -171,7 +157,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: 8.2
           extensions: mbstring
           tools: composer, cs2pr
 
@@ -198,7 +184,7 @@ jobs:
       - name: Install MediaWiki
         if: steps.cache-mediawiki.outputs.cache-hit != 'true'
         working-directory: ~
-        run: bash EarlyCopy/.github/workflows/installMediaWiki.sh REL1_39 Maps
+        run: bash EarlyCopy/.github/workflows/installMediaWiki.sh REL1_43 Maps
 
       - uses: actions/checkout@v4
         with:
@@ -231,7 +217,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: 8.2
           extensions: mbstring, intl, php-ast
           tools: composer
 
@@ -258,7 +244,7 @@ jobs:
       - name: Install MediaWiki
         if: steps.cache-mediawiki.outputs.cache-hit != 'true'
         working-directory: ~
-        run: bash EarlyCopy/.github/workflows/installMediaWiki.sh REL1_39 Maps
+        run: bash EarlyCopy/.github/workflows/installMediaWiki.sh REL1_43 Maps
 
       - uses: actions/checkout@v4
         with:

--- a/extension.json
+++ b/extension.json
@@ -12,7 +12,7 @@
 	"type": "parserhook",
 
 	"requires": {
-		"MediaWiki": ">= 1.35.0",
+		"MediaWiki": ">= 1.40.0",
 		"platform": {
 			"php": ">= 7.4"
 		}

--- a/src/GeoJsonPages/GeoJsonLegacyContent.php
+++ b/src/GeoJsonPages/GeoJsonLegacyContent.php
@@ -7,9 +7,9 @@ namespace Maps\GeoJsonPages;
 use Maps\GeoJsonPages\GeoJsonContent as GeoJsonPagesGeoJsonContent;
 use Maps\MapsFactory;
 use Maps\Presentation\OutputFacade;
+use MediaWiki\Title\Title;
 use ParserOptions;
 use ParserOutput;
-use Title;
 
 /**
  * @deprecated This class should be removed when Maps drops support for MediaWiki 1.37.

--- a/src/GeoJsonPages/GeoJsonMapPageUi.php
+++ b/src/GeoJsonPages/GeoJsonMapPageUi.php
@@ -4,7 +4,7 @@ declare( strict_types = 1 );
 
 namespace Maps\GeoJsonPages;
 
-use Html;
+use MediaWiki\Html\Html;
 use Maps\Presentation\OutputFacade;
 
 class GeoJsonMapPageUi {

--- a/src/GeoJsonPages/Semantic/SemanticGeoJsonStore.php
+++ b/src/GeoJsonPages/Semantic/SemanticGeoJsonStore.php
@@ -5,11 +5,11 @@ declare( strict_types = 1 );
 namespace Maps\GeoJsonPages\Semantic;
 
 use Maps\GeoJsonPages\GeoJsonStore;
+use MediaWiki\Title\Title;
 use Onoi\EventDispatcher\EventDispatcher;
 use SMW\DIProperty;
 use SMW\ParserData;
 use SMWDIContainer;
-use Title;
 
 class SemanticGeoJsonStore implements GeoJsonStore {
 

--- a/src/GoogleMapsService.php
+++ b/src/GoogleMapsService.php
@@ -4,7 +4,7 @@ declare( strict_types = 1 );
 
 namespace Maps;
 
-use Html;
+use MediaWiki\Html\Html;
 use Maps\Map\MapData;
 use ParamProcessor\ProcessedParam;
 use ParamProcessor\ProcessingResult;

--- a/src/LeafletService.php
+++ b/src/LeafletService.php
@@ -4,7 +4,7 @@ declare( strict_types = 1 );
 
 namespace Maps;
 
-use Html;
+use MediaWiki\Html\Html;
 use Maps\DataAccess\ImageRepository;
 use Maps\Map\MapData;
 use ParamProcessor\ParameterTypes;

--- a/src/LegacyMapEditor/MapEditorHtml.php
+++ b/src/LegacyMapEditor/MapEditorHtml.php
@@ -5,7 +5,7 @@ declare( strict_types = 1 );
 namespace Maps\LegacyMapEditor;
 
 use ContextSource;
-use Html;
+use MediaWiki\Html\Html;
 
 /**
  * Class to Handle HTML generation for Special:MapEditor

--- a/src/Map/MapHtmlBuilder.php
+++ b/src/Map/MapHtmlBuilder.php
@@ -5,7 +5,7 @@ declare( strict_types = 1 );
 namespace Maps\Map;
 
 use FormatJson;
-use Html;
+use MediaWiki\Html\Html;
 
 class MapHtmlBuilder {
 

--- a/src/Map/SemanticFormat/MapPrinter.php
+++ b/src/Map/SemanticFormat/MapPrinter.php
@@ -4,7 +4,7 @@ declare( strict_types = 1 );
 
 namespace Maps\Map\SemanticFormat;
 
-use Linker;
+use MediaWiki\Linker\Linker;
 use Maps\FileUrlFinder;
 use Maps\LegacyModel\BaseElement;
 use Maps\LegacyModel\Location;
@@ -16,11 +16,11 @@ use Maps\Presentation\WikitextParser;
 use Maps\SemanticMW\QueryHandler;
 use Maps\WikitextParsers\LocationParser;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
 use Parser;
 use SMW\Query\QueryResult;
 use SMW\Query\ResultPrinters\ResultPrinter;
 use SMWOutputs;
-use Title;
 
 /**
  * @licence GNU GPL v2+

--- a/src/MapsFactory.php
+++ b/src/MapsFactory.php
@@ -36,13 +36,13 @@ use Maps\WikitextParsers\PolygonParser;
 use Maps\WikitextParsers\RectangleParser;
 use Maps\WikitextParsers\WmsOverlayParser;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
 use ParamProcessor\ParamDefinitionFactory;
 use Parser;
 use RepoGroup;
 use SimpleCache\Cache\Cache;
 use SimpleCache\Cache\MediaWikiCache;
 use SMW\Services\ServicesFactory as ApplicationFactory;
-use Title;
 
 /**
  * @licence GNU GPL v2+

--- a/src/SemanticMW/QueryHandler.php
+++ b/src/SemanticMW/QueryHandler.php
@@ -4,8 +4,9 @@ declare( strict_types = 1 );
 
 namespace Maps\SemanticMW;
 
-use Html;
-use Linker;
+use MediaWiki\Html\Html;
+use MediaWiki\Linker\Linker;
+use MediaWiki\Title\Title;
 use Maps\LegacyModel\Location;
 use Maps\MapsFunctions;
 use MediaWiki\MediaWikiServices;
@@ -15,7 +16,6 @@ use SMW\Query\Result\ResultArray;
 use SMWDataValue;
 use SMWDIGeoCoord;
 use SMWWikiPageValue;
-use Title;
 
 /**
  * @licence GNU GPL v2+

--- a/src/WikitextParsers/LocationParser.php
+++ b/src/WikitextParsers/LocationParser.php
@@ -9,7 +9,7 @@ use Jeroen\SimpleGeocoder\Geocoder;
 use Maps\FileUrlFinder;
 use Maps\LegacyModel\Location;
 use Maps\MapsFactory;
-use Title;
+use MediaWiki\Title\Title;
 use ValueParsers\ParseException;
 use ValueParsers\StringValueParser;
 use ValueParsers\ValueParser;

--- a/tests/Integration/DataAccess/GeoJsonFetcherTest.php
+++ b/tests/Integration/DataAccess/GeoJsonFetcherTest.php
@@ -13,9 +13,7 @@ use Maps\DataAccess\GeoJsonFetcher;
 use Maps\GeoJsonPages\GeoJsonContent;
 use Maps\Tests\MapsTestFactory;
 use Maps\Tests\Util\PageCreator;
-use MediaWiki\MediaWikiServices;
 use PHPUnit\Framework\TestCase;
-use Title;
 
 /**
  * @covers \Maps\DataAccess\GeoJsonFetcher

--- a/tests/System/SemanticQueryTest.php
+++ b/tests/System/SemanticQueryTest.php
@@ -8,8 +8,8 @@ use Maps\DataAccess\PageContentFetcher;
 use Maps\Tests\MapsTestFactory;
 use Maps\Tests\Util\PageCreator;
 use Maps\Tests\Util\TestFactory;
+use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
-use Title;
 
 /**
  * @licence GNU GPL v2+

--- a/tests/Util/PageCreator.php
+++ b/tests/Util/PageCreator.php
@@ -4,8 +4,8 @@ declare( strict_types = 1 );
 
 namespace Maps\Tests\Util;
 
-use CommentStoreComment;
-use Title;
+use MediaWiki\CommentStore\CommentStoreComment;
+use MediaWiki\Title\Title;
 use User;
 
 /**


### PR DESCRIPTION
MediaWiki version has to be bumped upto MW 1.40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the extension’s MediaWiki dependency to require version 1.40.0 or higher.

- **Refactor**
  - Enhanced internal code consistency by clarifying library references to improve maintainability and stability.
  - Updated import statements to specify full namespaces for various classes, ensuring clarity and reducing ambiguity. 

- **Tests**
  - Simplified test dependencies by removing unused imports and updating class references to the correct namespaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->