### PR TITLE
Prevent explicit nullable type warning on modern PHP

### DIFF
--- a/src/MapsHooks.php
+++ b/src/MapsHooks.php
@@ -115,7 +115,7 @@ final class MapsHooks {
 		return true;
 	}
 
-	public static function onChangeTagsAllowedAdd( array &$allowedTags, array $tags, ?\User $user = null ) {
+	public static function onChangeTagsAllowedAdd( array &$allowedTags ) {
 		$allowedTags[] = 'maps-visual-edit';
 	}
 

--- a/src/MapsHooks.php
+++ b/src/MapsHooks.php
@@ -115,7 +115,7 @@ final class MapsHooks {
 		return true;
 	}
 
-	public static function onChangeTagsAllowedAdd( array &$allowedTags, array $tags, \User $user = null ) {
+	public static function onChangeTagsAllowedAdd( array &$allowedTags, array $tags, ?\User $user = null ) {
 		$allowedTags[] = 'maps-visual-edit';
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the method signature for handling allowed tags, reducing the number of parameters required. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->