### PR TITLE
Restore MapsFactory::getLeafletLayerDefinitions(), removed in 14.0.0

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -9,6 +9,7 @@ Not yet released
 
 * Added the `$egMapsAllowExternalKml` setting, also available as `general.allowExternalKml` on the `MediaWiki:Maps` page. Set it to `false` to have the Google Maps `kml` parameter accept only files on the wiki, and to stop `NetworkLink` elements inside a KML file from pointing anywhere else. It defaults to `true`, which keeps the existing behaviour of letting an editor have the browser of everyone viewing the map fetch KML from any host.
 * `NetworkLink` elements in KML files are now followed at most three levels deep, so a KML file that links back to itself no longer makes the browser fetch in an endless loop
+* Restored the `MapsFactory::getLeafletLayerDefinitions()` accessor that 14.0.0 removed. The Semantic Result Formats filtered format uses it to resolve custom layer names in its `map view layers` parameter, so on Maps 14.0.0 to 14.1.1 custom names there were silently skipped. The restored accessor also includes layer definitions set on the `MediaWiki:Maps` page, which the 13.1.x one did not.
 
 ## Maps 14.1.1
 

--- a/src/MapsFactory.php
+++ b/src/MapsFactory.php
@@ -214,6 +214,15 @@ class MapsFactory {
 		return $this->leafletService;
 	}
 
+	/**
+	 * Public accessor for other extensions bridging to the custom Leaflet layers, such as the
+	 * Semantic Result Formats filtered format. Backed by the effective settings, so definitions
+	 * from both LocalSettings.php and the MediaWiki:Maps config page are included.
+	 */
+	public function getLeafletLayerDefinitions(): LeafletLayerDefinitions {
+		return new LeafletLayerDefinitions( $this->getEffectiveSettings()->get( 'egMapsLeafletLayerDefinitions' ) );
+	}
+
 	public function getEffectiveSettings(): EffectiveSettings {
 		$this->effectiveSettings ??= new EffectiveSettings(
 			$this->settings,

--- a/tests/Integration/Config/OnWikiConfigTest.php
+++ b/tests/Integration/Config/OnWikiConfigTest.php
@@ -73,6 +73,20 @@ class OnWikiConfigTest extends TestCase {
 		);
 	}
 
+	/**
+	 * @covers \Maps\MapsFactory::getLeafletLayerDefinitions
+	 */
+	public function testLeafletLayerDefinitionsAccessorSeesWikiDefinitions(): void {
+		MapsTestFactory::$wikiConfig = [ 'leaflet' => [ 'layerDefinitions' => [
+			'FromWiki' => [ 'url' => 'https://wiki.example/{z}/{x}/{y}.png' ],
+		] ] ];
+		$factory = MapsTestFactory::newTestInstance();
+
+		$definitions = $factory->getLeafletLayerDefinitions()->getDefinitions( [ 'FromWiki' ] );
+
+		$this->assertSame( 'https://wiki.example/{z}/{x}/{y}.png', $definitions['FromWiki']['url'] );
+	}
+
 	public function testWikiLeafletDefaultZoomReachesTheParameterDefault(): void {
 		MapsTestFactory::$wikiConfig = [ 'leaflet' => [ 'defaultZoom' => 7 ] ];
 		$factory = MapsTestFactory::newTestInstance();


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/Maps/issues/936

Maps 13.1.0 added the accessor together with the $egMapsLeafletLayerDefinitions setting (#921). The Semantic Result Formats filtered format resolves custom layer names in its `map view layers` parameter through it, guarded by method_exists() so Maps stays an optional dependency. 14.0.0 removed the accessor, so on 14.x the guard fails and custom layer names are silently skipped, the same degradation as Maps not being installed at all.

The restored accessor reads the effective settings, so unlike the 13.1.x one it also returns definitions set on the MediaWiki:Maps page. It mirrors LeafletService, keeping LeafletLayerDefinitions as the single normalization and hardening path, and the MediaWiki:Maps read stays lazy, at parse time.

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; regression found and fix designed in-session, one-line asks from @kghbln, no revisions; diff reviewed by @kghbln before pushing; new regression test not run locally (no MediaWiki in the sandbox), CI is the gate; the degradation chain was verified statically against the 13.1.0-14.1.1 tags and the SRF client code.</sub>
